### PR TITLE
fix(main-page)/ carousel이 밖으로 나가는 현상 해결

### DIFF
--- a/scss/pages/_main.scss
+++ b/scss/pages/_main.scss
@@ -61,6 +61,7 @@ main {
     left: 50%;
     transform: translateX(-50%);
     bottom: -20px;
+    z-index: 10;
   }
 }
 .carousel-container_indicator {


### PR DESCRIPTION
## 🐛 버그 수정 PR

### 🔍 문제 상황
캐러셀에 사용한 이미지가 컨테이너 오른쪽으로 튀어나오는 현상

#### 버그 설명
<!-- 어떤 버그가 발생했는지 설명 -->
캐러셀을 만들기 위해 배치한 이미지가 화면 밖으로 튀어나오는 현상.

#### 예상 동작
<!-- 정상적으로 동작해야 하는 방식 -->
캐러셀의 좌 우 버튼을 누르면 이미지가 넘어가지만 컨테이너의 크기는 화면 크기로 고정


#### 실제 동작
<!-- 실제로 발생한 문제 상황 -->
이미지의 크기만큼 캐러셀 컨테이너의 오른쪽으로 이미지가 튀어나와 좌우 스크롤이 생김


### 🔧 해결 방법
<!-- 버그를 어떻게 수정했는지 설명해주세요 -->
컨테이너에 overflow : hidden; 으로 css를 수정

#### 원인 분석
<!-- 버그가 발생한 원인 -->
overflow : hidden;누락

#### 수정 내용
<!-- 구체적인 수정 사항 -->

- [scss] 
```scss
.carousel-container {
  position: relative;
  overflow: hidden; // overflow hidden 추가
  height: 500px;
  display: flex;
  flex-direction: row;
}
```
### 📱 스크린샷 / 동영상
<!-- 버그 수정 전후 비교 -->

#### Before (수정 전)
<!-- 버그 발생 시 이미지/동영상 -->
![화면 기록 2025-07-24 14 36 17](https://github.com/user-attachments/assets/d2c984c2-4b02-4652-a9b0-9f46d12479e6)


#### After (수정 후)
<!-- 수정 완료 후 이미지/동영상 -->
![화면 기록 2025-07-24 10 37 23](https://github.com/user-attachments/assets/cd0b1daa-b657-448e-86fc-dda959daa77e)



### 🧪 테스트
<!-- 버그 수정을 어떻게 검증했는지 작성 -->

#### 수정 검증 방법
1. [✅] 원래 재현 단계로 버그가 해결되었는지 확인
2. [] 다양한 브라우저에서 테스트
3. [✅] 모바일 환경에서 테스트
4. [✅] 관련 기능에 영향이 없는지 확인


### 🔗 관련 이슈
<!-- 관련된 버그 리포트 이슈 -->

Fixes #29 

### 🚨 영향 범위
<!-- 이 수정이 다른 기능에 미칠 수 있는 영향 -->

- [✅] 수정 범위가 제한적임 (해당 기능만 영향)
- [ ] 다른 기능에 영향 가능성 있음
- [ ] 전체적인 영향 확인 필요

### 📋 체크리스트

- [✅] 버그의 근본 원인을 파악했습니다
- [✅] 비슷한 버그가 다른 곳에 있는지 확인했습니다
- [✅] 수정이 다른 기능에 영향을 주지 않는지 확인했습니다
- [✅] 코드 컨벤션을 준수했습니다
- [✅] 적절한 주석을 추가했습니다



**긴급도: [ ] 높음 [ ] 보통 [✅] 낮음**
**리뷰어: @jiunlee19  @cheul-95 **