### PR TITLE
feat(main-page)/캐러셀 자동으로 넘기는 스크립트 추가

### DIFF
--- a/js/pages/main/components/carousel.js
+++ b/js/pages/main/components/carousel.js
@@ -7,6 +7,7 @@ export function carouselControl() {
     ".carousel-container_indicator"
   );
   let count = 0;
+  let autoSlideCarousel;
 
   //캐러셀 이미지 배열
   const carouselImage = [
@@ -34,6 +35,29 @@ export function carouselControl() {
   }
 
   /**
+   * 캐러셀 슬라이드 자동으로 넘기는 함수
+   */
+  function autoSlide() {
+    count++;
+    if (count > carouselImage.length - 1) {
+      count = 0;
+    }
+    carouselSlide.style.transform = `translateX(-${count * 100}%)`;
+    renderCarouselIndicator();
+  }
+
+  /**
+   * 3초마다 슬라이드
+   */
+  function startAutoSlide() {
+    autoSlideCarousel = setInterval(autoSlide, 3000);
+  }
+
+  function stopAutoSlide() {
+    clearInterval(autoSlideCarousel);
+  }
+
+  /**
    * 캐러셀 이미지 베열을 순회하면서 li로 이미지를 추가하는 함수
    */
   function renderCarouselImages() {
@@ -53,10 +77,17 @@ export function carouselControl() {
 
   renderCarouselImages();
   renderCarouselIndicator();
+
+  startAutoSlide();
+
   carouselButton1?.addEventListener("click", () => {
+    stopAutoSlide();
     carouselButton(carouselButton1);
+    startAutoSlide();
   });
   carouselButton2?.addEventListener("click", () => {
+    stopAutoSlide();
     carouselButton(carouselButton2);
+    startAutoSlide();
   });
 }


### PR DESCRIPTION
## 🚀 기능 개발 PR

### 📝 변경 사항

캐러셀을 3초마다 자동으로 슬라이드하는 기능 추가

- [✅] 새로운 기능 구현
- [✅] 기존 기능 개선
- [✅] UI/UX 변경
- [ ] 성능 최적화
- [ ] 기타: 

### 🎯 구현된 기능
<!-- 구현한 기능을 체크리스트로 작성해주세요 -->

- [캐러셀 자동슬라이드] 기능 1: 캐러셀 이미지가 3초마다 자동으로 슬라이드

### 📱 스크린샷 / 동영상


![화면 기록 2025-07-29 오전 10 18 16](https://github.com/user-attachments/assets/3d80823e-5568-43d2-b59e-6c4cc8e03618)

### 🧪 테스트

✅ 자동으로 넘어가는지 확인
✅ 버튼을 눌렀을때 멈췄다가 넘어가는지 확인


#### 테스트 환경
- [✅] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Mobile (iOS/Android)

#### 테스트 시나리오
1. [✅] 기본 동작 테스트
2. [ ] 예외 상황 테스트
3. [ ] 반응형 테스트
4. [ ] 접근성 테스트



### 📋 체크리스트
<!-- PR 제출 전 확인사항 -->

- [✅] 코드 컨벤션을 준수했습니다
- [✅] 커밋 메시지가 컨벤션에 맞습니다
- [✅] 코드에 주석을 적절히 작성했습니다
- [✅] 불필요한 코드를 제거했습니다
- [✅] 브라우저 호환성을 확인했습니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 접근성을 고려했습니다


---

**리뷰어: @jiunlee19  @cheul-95 **