### PR TITLE
fix(product-page)/style 중복 선언 수정

### DIFF
--- a/scss/pages/_index.scss
+++ b/scss/pages/_index.scss
@@ -1,6 +1,5 @@
 @forward "cart";
 @forward "main";
-@forward "product-detail";
 @forward "product";
 @forward "error";
 @forward "login";

--- a/scss/pages/_product.scss
+++ b/scss/pages/_product.scss
@@ -348,25 +348,16 @@ $heavy-fw: 700;
     margin-top: 10px;
   }
 }
+
 .product-tab {
   display: flex;
   justify-content: center;
-  width: 100vh;
-}
-.product-tab {
-  display: flex;
-  justify-content: center;
-  width: 100vh;
+  width: 100%;
 
   &__list {
     width: 80%;
   }
-  &__content {
-    width: 80%;
-    margin: 50px auto;
-  }
 }
-
 .divider {
   margin: 0 11px;
   color: $lightgray;


### PR DESCRIPTION
## 🐛 버그 수정 PR

### 🔍 문제 상황
상품 상세페이지 하단의 ul이 왼쪽으로 치우치는 현상

#### 예상 동작
<!-- 정상적으로 동작해야 하는 방식 -->
전체 너비의 80%로 렌더링되어야 함

#### 실제 동작
<!-- 실제로 발생한 문제 상황 -->
왼쪽으로 치우쳐서 렌더링

### 🔧 해결 방법
<!-- 버그를 어떻게 수정했는지 설명해주세요 -->
scss파일 내에 중복 선언된 내용 통일
일부 속성의 높이를 80vh에서 80%로 수정

#### 원인 분석
같은 클래스 복수 선언



### 📱 스크린샷 / 동영상
<!-- 버그 수정 전후 비교 -->

<img width="1136" height="551" alt="스크린샷 2025-07-29 오후 1 58 06" src="https://github.com/user-attachments/assets/32299ea9-94a0-49e8-956f-ed3b7a86e5ca" />

#### 수정 검증 방법
1. [✅] 원래 재현 단계로 버그가 해결되었는지 확인
2. [ ] 다양한 브라우저에서 테스트
3. [ ] 모바일 환경에서 테스트
4. [✅] 관련 기능에 영향이 없는지 확인


### 🚨 영향 범위
<!-- 이 수정이 다른 기능에 미칠 수 있는 영향 -->

- [✅] 수정 범위가 제한적임 (해당 기능만 영향)
- [ ] 다른 기능에 영향 가능성 있음
- [ ] 전체적인 영향 확인 필요

### 📋 체크리스트

- [✅] 버그의 근본 원인을 파악했습니다
- [✅] 비슷한 버그가 다른 곳에 있는지 확인했습니다
- [✅] 수정이 다른 기능에 영향을 주지 않는지 확인했습니다
- [✅] 코드 컨벤션을 준수했습니다
- [✅] 적절한 주석을 추가했습니다

---

**긴급도: [ ] 높음 [ ] 보통 [ ] 낮음**
**리뷰어: @jiunlee19 @cheul-95 **