### PR TITLE
Refactor(product detail order list): 장바구니 페이지로 이동 구현

### DIFF
--- a/js/pages/product_detail/components/getActionButtons.js
+++ b/js/pages/product_detail/components/getActionButtons.js
@@ -81,9 +81,15 @@ export function getActionButtons(productId, stock) {
       }
 
       const result = await response.json();
-      console.log("장바구니 추가 성공:", result);
-      alert("상품이 장바구니에 추가되었습니다.");
-      sessionStorage.removeItem("cartItemToAdd");
+      const confirmMoveToCart = confirm(
+        "상품이 장바구니에 추가되었습니다!\n장바구니 페이지로 이동하시겠습니까?"
+      );
+
+      if (confirmMoveToCart) {
+        window.location.href = "/pages/cart.html";
+      } else {
+        console.log("장바구니 이동을 취소했습니다.");
+      }
     } catch (error) {
       console.error("장바구니 추가 중 오류:", error);
       alert("장바구니 추가 중 오류가 발생했습니다.");


### PR DESCRIPTION
**작업 개요**
장바구니에 상품 추가 후 장바구니 페이지로 이동할 것인지 묻는 부분을 추가했습니다.

**구현 결과**

<img width="458" height="181" alt="스크린샷 2025-07-29 오후 3 17 44" src="https://github.com/user-attachments/assets/7285c081-35bd-457b-bc65-4b155f99676f" />

장바구니에 상품 추가 후, 장바구니 페이지로 이동할 것인지 묻습니다.
'취소'를 누르면 해당 confirm창이 닫히고, '확인'을 누르면 장바구니 페이지로 이동합니다.

**체크리스트**
- [x] 정상적으로 작동하는지 확인했습니다.