### PR TITLE
fix(header)/로그인 만료시 login,html로 이동시켜 무한루프 발생현상 해결

### DIFF
--- a/js/components/header.js
+++ b/js/components/header.js
@@ -1,14 +1,11 @@
-import { refreshAccessToken } from "/js/pages/login/api.js";
-import { clearAuth, getAccessToken } from "/js/pages/login/auth.js";
+import { getAccessToken } from "/js/pages/login/auth.js";
 export function initHeader() {
   //헤더를 위한 js파일입니다.
   //로그인 유무에따른 마이페이지 ,로그인 텍스트 변경
   const $headerMenuLogin = document.querySelector(".header__menu-login");
   const $headerDropdown = document.querySelector(".dropdown");
   const $searchForm = document.querySelector(".header__search-form");
-  refreshAccessToken().then(result => {
-    if (!result) clearAuth(); // false
-  });
+
   const token = getAccessToken();
   if (token) {
     $headerDropdown.style.display = "block";


### PR DESCRIPTION
## 🐛 버그 수정 PR

### 🔍 문제 상황
<!-- 발생한 버그에 대해 상세히 설명해주세요 -->
로그아웃 등 로그인 만료 상황에서 로그인없이 login.html에서 벗어날 수 없는 현상

#### 버그 설명
<!-- 어떤 버그가 발생했는지 설명 -->

#### 재현 단계
1. 로그인 만료시 login.html로 이동
2. index.html로 이동하는 링크 클릭시 토큰유효성검사를 호출해서 다시 login.html로 이동


#### 예상 동작
<!-- 정상적으로 동작해야 하는 방식 -->
로그인을 하지 않고 index.html로 이동하는 링크를 누르면 login.html로 이동



### 🔧 해결 방법
<!-- 버그를 어떻게 수정했는지 설명해주세요 -->
header.js에서 
```js
refreshAccessToken().then(result => {
    if (!result) clearAuth(); // false
  });
  ```
삭제

#### 원인 분석
<!-- 버그가 발생한 원인 -->
로그아웃 -> login.html로 이동 -> index.html로 이동시 헤더를 로드하면서 refreshToken으로 토큰 갱신 시도 -> 갱신 실패 -> 로그인페이지로 이동


#### 수정 내용
<!-- 구체적인 수정 사항 -->

- [✅] 수정 사항 1 리프레시 토큰 호출 함수 삭제 (필요한 페이지에서 로드하도록 수정)

#### 수정 검증 방법
1. [✅] 원래 재현 단계로 버그가 해결되었는지 확인
2. [ ] 다양한 브라우저에서 테스트
3. [ ] 모바일 환경에서 테스트
4. [ ] 관련 기능에 영향이 없는지 확인

#### 추가 테스트 케이스
- [✅] 정상 케이스 테스트
- [ ] 경계값 테스트
- [ ] 예외 상황 테스트

### 🔗 관련 이슈
<!-- 관련된 버그 리포트 이슈 -->

Fixes #67 

### 🚨 영향 범위
<!-- 이 수정이 다른 기능에 미칠 수 있는 영향 -->

- [ ] 수정 범위가 제한적임 (해당 기능만 영향)
- [✅] 다른 기능에 영향 가능성 있음
- [ ] 전체적인 영향 확인 필요

### 📋 체크리스트

- [✅] 버그의 근본 원인을 파악했습니다
- [✅] 비슷한 버그가 다른 곳에 있는지 확인했습니다
- [✅] 수정이 다른 기능에 영향을 주지 않는지 확인했습니다
- [✅] 코드 컨벤션을 준수했습니다
- [✅] 적절한 주석을 추가했습니다

### 💬 리뷰어에게
<!-- 리뷰어가 특별히 주의해서 봐야 할 부분 -->
헤더에서 refreshToken을 가져오던 페이지에서 정상기능 작동하는지 확인 부탁드립니다.
---

**긴급도: [✅] 높음 [ ] 보통 [ ] 낮음**
**리뷰어: @jiunlee19  @cheul-95 **